### PR TITLE
#4 Добавлен CI пайплайн для фронтенда

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -44,6 +44,7 @@ jobs:
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
+          SONAR_PROJECT_KEY: ${{ secrets.SONAR_PROJECT_KEY }}
         run: |
           cd backend
-          mvn org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=NikitaBuffy_lenka-messenger_2c716e46-ed88-4385-b66c-97e4f1653f48 -Dsonar.projectName='lenka-messenger' -Dsonar.pullrequest.key=${{ github.event.number}} -Dsonar.pullrequest.branch=${{ github.event.pull_request.head.ref }} -Dsonar.pullrequest.base=${{ github.event.pull_request.base.ref }} -Dsonar.scm.revision=${{ github.event.pull_request.head.sha }}
+          mvn org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=$SONAR_PROJECT_KEY -Dsonar.projectName='lenka-messenger' -Dsonar.pullrequest.key=${{ github.event.number}} -Dsonar.pullrequest.branch=${{ github.event.pull_request.head.ref }} -Dsonar.pullrequest.base=${{ github.event.pull_request.base.ref }} -Dsonar.scm.revision=${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -28,10 +28,20 @@ jobs:
             ${{ runner.os }}-node-
 
       - name: Install dependencies
-        run: npm install
+        run: |
+          cd frontend
+          npm install
 
       - name: Build frontend
-        run: npm run build
+        run: |
+          cd frontend
+          npm run build
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
 
       - name: Cache SonarQube packages
         uses: actions/cache@v4
@@ -44,6 +54,7 @@ jobs:
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
+          SONAR_PROJECT_KEY: ${{ secrets.SONAR_PROJECT_KEY }}
         run: |
           cd frontend
-          npx sonar-scanner -Dsonar.projectKey=NikitaBuffy_lenka-messenger_2c716e46-ed88-4385-b66c-97e4f1653f48 -Dsonar.projectName='lenka-messenger' -Dsonar.sources=src -Dsonar.pullrequest.key=${{ github.event.number}} -Dsonar.pullrequest.branch=${{ github.event.pull_request.head.ref }} -Dsonar.pullrequest.base=${{ github.event.pull_request.base.ref }} -Dsonar.scm.revision=${{ github.event.pull_request.head.sha }}
+          npx sonar-scanner -Dsonar.projectKey=$SONAR_PROJECT_KEY -Dsonar.projectName='lenka-messenger' -Dsonar.sources=src -Dsonar.pullrequest.key=${{ github.event.number}} -Dsonar.pullrequest.branch=${{ github.event.pull_request.head.ref }} -Dsonar.pullrequest.base=${{ github.event.pull_request.base.ref }} -Dsonar.scm.revision=${{ github.event.pull_request.head.sha }} -Dsonar.host.url=$SONAR_HOST_URL

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -1,0 +1,49 @@
+name: Vue CI
+
+on:
+  pull_request:
+    branches:
+      - frontend
+  workflow_dispatch:
+
+jobs:
+  build-and-analyze:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+
+      - name: Cache Node.js dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build frontend
+        run: npm run build
+
+      - name: Cache SonarQube packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+
+      - name: Analyze with SonarQube
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
+        run: |
+          cd frontend
+          npx sonar-scanner -Dsonar.projectKey=NikitaBuffy_lenka-messenger_2c716e46-ed88-4385-b66c-97e4f1653f48 -Dsonar.projectName='lenka-messenger' -Dsonar.sources=src -Dsonar.pullrequest.key=${{ github.event.number}} -Dsonar.pullrequest.branch=${{ github.event.pull_request.head.ref }} -Dsonar.pullrequest.base=${{ github.event.pull_request.base.ref }} -Dsonar.scm.revision=${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/main-restrict.yml
+++ b/.github/workflows/main-restrict.yml
@@ -1,0 +1,23 @@
+name: Restrict PR to Main
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  restrict-branches:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check source branch
+        run: |
+          echo "Checking source branch..."
+          ALLOWED_BRANCHES=("backend" "frontend" "devops")
+          SOURCE_BRANCH=$(echo "${{ github.event.pull_request.head.ref }}")
+          
+          if [[ ! " ${ALLOWED_BRANCHES[@]} " =~ " ${SOURCE_BRANCH} " ]]; then
+            echo "Pull Request from branch '${SOURCE_BRANCH}' to 'main' is not allowed!"
+            exit 1
+          else
+            echo "Pull Request from '${SOURCE_BRANCH}' is allowed."
+          fi


### PR DESCRIPTION
Написан CI пайплайн при открытии PR в ветку frontend. Пайплайн включает проверку, сборку, кэширование зависимостей и анализ кода с помощью SonarQube. Дополнительно настроено автоматическое декорирование пулл-реквестов результатами анализа сонара с блокировкой мерджа в случае возникновения проблем.

Настроен пайплайн, который запрещает делать pull-request в main из любой ветки, кроме backend, frontend, devops