### PR TITLE
#7 CI/CD пайплайн для ветки main

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -33,6 +33,12 @@ jobs:
           cd backend
           mvn clean verify
 
+      - name: Upload backend build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: backend-jar
+          path: /backend/target/*.jar
+
       - name: Cache SonarQube packages
         uses: actions/cache@v4
         with:

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -37,6 +37,12 @@ jobs:
           cd frontend
           npm run build
 
+      - name: Upload frontend build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: frontend-dist
+          path: frontend/dist/
+
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,6 +23,18 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
+      - name: Download backend artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: backend-jar
+          path: backend/target/
+
+      - name: Download frontend artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: frontend-dist
+          path: frontend/dist/
+
       - name: Build and Push Frontend Image
         run: |
           cd frontend

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,47 @@
+name: Main CI/CD
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  build-image-and-push:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build and Push Frontend Image
+        run: |
+          cd frontend
+          docker build -t nickpominov/lm-frontend:latest .
+          docker push nickpominov/lm-frontend:latest
+
+      - name: Build and Push Backend Image
+        run: |
+          cd backend
+          docker build -t nickpominov/lm-backend:latest .
+          docker push nickpominov/lm-backend:latest
+
+      - name: Deploy to remote server
+        uses: appleboy/ssh-action@v0.1.7
+        with:
+          host: ${{ secrets.SERVER_IP }}
+          username: ${{ secrets.SSH_USERNAME }}
+          password: ${{ secrets.SSH_PASSWORD }}
+          port: 22
+          script: |
+            cd /srv/lenka-messenger
+            docker-compose -f docker-compose.prod.yaml up -d --no-deps lm-backend lm-frontend

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,13 +1,13 @@
-name: Main CI/CD
+name: Main CD
 
 on:
-  push:
-    branches:
-      - main
+  pull_request:
+    types: [closed]
   workflow_dispatch:
 
 jobs:
-  build-image-and-push:
+  cd-backend:
+    if: github.event.pull_request.merged == true && github.event.pull_request.head.ref == 'backend'
     runs-on: ubuntu-latest
 
     steps:
@@ -23,13 +23,47 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Download backend artifact
+      - name: Download Backend Artifact
         uses: actions/download-artifact@v4
         with:
           name: backend-jar
           path: backend/target/
 
-      - name: Download frontend artifact
+      - name: Build and Push Backend Image
+        run: |
+          cd backend
+          docker build -t nickpominov/lm-backend:latest .
+          docker push nickpominov/lm-backend:latest
+
+      - name: Deploy Backend to Remote Server
+        uses: appleboy/ssh-action@v0.1.7
+        with:
+          host: ${{ secrets.SERVER_IP }}
+          username: ${{ secrets.SSH_USERNAME }}
+          password: ${{ secrets.SSH_PASSWORD }}
+          port: 22
+          script: |
+            cd /srv/lenka-messenger
+            docker-compose -f docker-compose.prod.yaml up -d --no-deps lm-backend
+
+  cd-frontend:
+    if: github.event.pull_request.merged == true && github.event.pull_request.head.ref == 'frontend'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Download Frontend Artifact
         uses: actions/download-artifact@v4
         with:
           name: frontend-dist
@@ -41,13 +75,7 @@ jobs:
           docker build -t nickpominov/lm-frontend:latest .
           docker push nickpominov/lm-frontend:latest
 
-      - name: Build and Push Backend Image
-        run: |
-          cd backend
-          docker build -t nickpominov/lm-backend:latest .
-          docker push nickpominov/lm-backend:latest
-
-      - name: Deploy to remote server
+      - name: Deploy Frontend to Remote Server
         uses: appleboy/ssh-action@v0.1.7
         with:
           host: ${{ secrets.SERVER_IP }}
@@ -56,4 +84,4 @@ jobs:
           port: 22
           script: |
             cd /srv/lenka-messenger
-            docker-compose -f docker-compose.prod.yaml up -d --no-deps lm-backend lm-frontend
+            docker-compose -f docker-compose.prod.yaml up -d --no-deps lm-frontend

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -1,0 +1,58 @@
+version: '3.9'
+
+services:
+  lm-backend:
+    build:
+      context: ./backend
+    container_name: lm-backend
+    ports:
+      - "8080:8080"
+    depends_on:
+      - postgres
+    environment:
+      - SPRING_DATASOURCE_URL=jdbc:postgresql://postgres:5432/lenkamessenger
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+    networks:
+      - app-network
+    restart: unless-stopped
+
+  lm-frontend:
+    build:
+      context: ./frontend
+    container_name: lm-frontend
+    ports:
+      - "3000:80"
+    networks:
+      - app-network
+    restart: unless-stopped
+
+  postgres:
+    image: postgres:14-alpine
+    container_name: postgres
+    ports:
+      - "6551:5432"
+    volumes:
+      - /var/lib/postgresql/data
+    environment:
+      - POSTGRES_DB=lenkamessenger
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+      - TZ=GMT
+    networks:
+      - app-network
+
+  pgadmin:
+    image: dpage/pgadmin4
+    container_name: pgadmin
+    environment:
+      PGADMIN_DEFAULT_EMAIL: admin@admin.ru
+      PGADMIN_DEFAULT_PASSWORD: admin
+    ports:
+      - "5050:80"
+    networks:
+      - app-network
+
+networks:
+  app-network:
+    driver: bridge

--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -2,10 +2,8 @@ version: '3.9'
 
 services:
   lm-backend:
-    build:
-      context: ./backend
+    image: nickpominov/lm-backend:latest
     container_name: lm-backend
-    image: lm-backend:latest
     ports:
       - "8080:8080"
     depends_on:
@@ -19,12 +17,10 @@ services:
     restart: unless-stopped
 
   lm-frontend:
-    build:
-      context: ./frontend
+    image: nickpominov/lm-frontend:latest
     container_name: lm-frontend
-    image: lm-frontend:latest
     ports:
-      - "80:80"
+      - "3000:80"
     networks:
       - app-network
     restart: unless-stopped

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,4 +1,3 @@
-FROM nginx:1.25-alpine
-COPY dist /usr/share/nginx/html
+FROM caddy:alpine
+COPY ./dist /usr/share/caddy
 EXPOSE 80
-CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
Написан пайплайн, срабатывающий при пуше в ветку main, который собирает образы Docker для frontend и backend, затем пушит в Docker Hub, подключается на удаленный сервер и перезапускает контейнеры с новыми образами. Тем самым обеспечивая полноту принципов CI/CD, автоматизируя доставку изменений на удаленный сервер.