### PR TITLE
#7 Фикс запуска CD пайплайна

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,6 +3,8 @@ name: Main CD
 on:
   pull_request:
     types: [closed]
+    branches:
+      - main
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
До этого Main CD пайплайн запускался на все pull-request, просто из-за внутренних конструкций _if_ задачи скипались. Теперь добавлен фильтр на запуск только по успешному мерджу в _main_.